### PR TITLE
add missing dependecies to arch-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is my attempt to make Amazon Games useful for Linux users, who want to play
 
 # Dependencies
 ## Arch, Manjaro etc..
-`sudo pacman -Sy pyqt5 python-pycryptodome python-zstandard python-requests`
+`sudo pacman -Sy pyqt5 python-pycryptodome python-zstandard python-requests python-protobuf`
 ## Ubuntu
 `sudo apt install python3-pyqt5 python3-pycryptodome python3-requests python3-zstd`
 ## With pip


### PR DESCRIPTION
I use arch and  had the problem stated in issue #8 
Install python-protobuf solved it, so i added it to the README.