### PR TITLE
fix launch failure when game has no Main.Args

### DIFF
--- a/nile/utils/launch.py
+++ b/nile/utils/launch.py
@@ -23,10 +23,7 @@ class LaunchInstruction:
         stream.close()
         instruction.version = json_data["SchemaVersion"]
         instruction.command = os.path.join(game_path, json_data["Main"]["Command"])
-        if "Args" in json_data["Main"]:
-            instruction.arguments = json_data["Main"]["Args"]
-        else:
-            instruction.arguments = []
+        instruction.arguments = json_data["Main"].get("Args") or list()
         instruction.arguments.extend(unknown_arguments)
         return instruction
 

--- a/nile/utils/launch.py
+++ b/nile/utils/launch.py
@@ -23,7 +23,10 @@ class LaunchInstruction:
         stream.close()
         instruction.version = json_data["SchemaVersion"]
         instruction.command = os.path.join(game_path, json_data["Main"]["Command"])
-        instruction.arguments = json_data["Main"]["Args"]
+        if "Args" in json_data["Main"]:
+            instruction.arguments = json_data["Main"]["Args"]
+        else:
+            instruction.arguments = []
         instruction.arguments.extend(unknown_arguments)
         return instruction
 


### PR DESCRIPTION
this fixes a bug where the launch command fails if the game doesn't have `Main.Args` present (which is the case with Titan Souls, ID: 353f3a18-8bcf-48d5-8b78-3b37d9a136ce)