### PR TITLE
feat: implemented non-interactive login flow

### DIFF
--- a/nile/arguments.py
+++ b/nile/arguments.py
@@ -12,9 +12,16 @@ def get_arguments():
 
     auth_parser = sub_parsers.add_parser("auth", help="Authorization related things")
     auth_parser.add_argument("--login", "-l", action="store_true", help="Login action")
+    auth_parser.add_argument("--non-interactive", action="store_true", help="Display login data as JSON. Use `nile register` to finish login")
     auth_parser.add_argument(
         "--logout", action="store_true", help="Logout from the accout and deregister"
     )
+
+    register_parser = sub_parsers.add_parser("register", help="Register device after web login")
+    register_parser.add_argument("--code", help="The authorization code from web login")
+    register_parser.add_argument("--client-id", help="The client id to register")
+    register_parser.add_argument("--code-verifier", help="The code verifier used to generate login URL")
+    register_parser.add_argument("--serial", help="The device serial to register")
 
     library_parser = sub_parsers.add_parser(
         "library", help="Your games library is in this place"

--- a/nile/cli.py
+++ b/nile/cli.py
@@ -31,7 +31,7 @@ class CLI:
     def handle_auth(self):
         if self.arguments.login:
             if not self.auth_manager.is_logged_in():
-                self.auth_manager.login()
+                self.auth_manager.login(self.arguments.non_interactive)
                 return True
             else:
                 self.logger.error("You are already logged in")
@@ -40,6 +40,32 @@ class CLI:
             self.auth_manager.logout()
             return False
         self.logger.error("Specify auth action, use --help")
+    
+    def handle_register(self):
+        if self.auth_manager.is_logged_in():
+            self.logger.error("You are already logged in")
+            return False
+
+        code = self.arguments.code
+        client_id = self.arguments.client_id
+        code_verifier = self.arguments.code_verifier
+        serial = self.arguments.serial
+
+        if not code:
+            self.logger.error("--code is required, use --help")
+            return False
+        if not client_id:
+            self.logger.error("--client-id is required, use --help")
+            return False
+        if not code_verifier:
+            self.logger.error("--code-verifier is required, use --help")
+            return False
+        if not serial:
+            self.logger.error("--serial is required, use --help")
+            return False
+
+        self.auth_manager.handle_login(code, client_id, code_verifier, serial)
+        return True
 
     def sort_by_title(self, element):
         return (
@@ -214,7 +240,8 @@ def main():
 
     if command == "auth":
         cli.handle_auth()
-
+    elif command == "register":
+        cli.handle_register()
     elif command == "library":
         cli.handle_library()
     elif command in ["install", "verify", "update"]:


### PR DESCRIPTION
Closes #27 

## Non-interactive Login Support

This PR adds the ability to login without having to go through the interactive login flow (aka currently the only way to login)

## Changes

- Added `--non-interactive` flag to `auth` parser. When enabled, the CLI will output the required data to complete a login as JSON and exit
- Added `register` parser. This parser takes the `client_id`, `code_verifier` and `serial` provided by `auth --login --non-interactive`, as well as the authorization code extracted by the user from the redirect url after web login

## Example flow

A user calls `nile auth --login --non-interactive`. Example output:

```json
{
  "client_id": "4538354532414338313846393131454541343733443843423841353038303341234132554d56484f58375550345637",
  "code_verifier": "ZiT3nDc3NNeEQysbk4O65E1b7FG3-UhL-DqopBcir4g",
  "serial": "E85E2AC818F911EEA473D8CB8A50803A",
  "url": "https://amazon.com/ap/signin?openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.oa2.scope=device_auth_access&openid.ns.oa2=http%3A%2F%2Fwww.amazon.com%2Fap%2Fext%2Foauth%2F2&openid.oa2.response_type=code&openid.oa2.code_challenge_method=S256&openid.oa2.client_id=device%3A4538354532414338313846393131454541343733443843423841353038303341234132554d56484f58375550345637&language=en_US&marketPlaceId=ATVPDKIKX0DER&openid.return_to=https%3A%2F%2Fwww.amazon.com&openid.pape.max_auth_age=0&openid.assoc_handle=amzn_sonic_games_launcher&pageId=amzn_sonic_games_launcher&openid.oa2.code_challenge=L2hAj3KpxhxvHjdn4_zVuDdB8cS9zz6pjX7JMbHMjHs"
}
```

The user then follows the `url` and completes the web login.

After that, they take the authorization code from the `openid.oa2.authorization_code` query parameter in the redirect URL.

Finally, the user calls `nile register --code AUTHORIZATION_CODE --client-id CLIENT_ID --code-verifier CODE_VERIFIER --serial SERIAL`.

After this, the user is logged in.