### PR TITLE
feat: add --info flag to install action

### DIFF
--- a/nile/arguments.py
+++ b/nile/arguments.py
@@ -43,6 +43,9 @@ def get_arguments():
     install_parser.add_argument(
         "--path", dest="exact_path", help="Specify exact install location"
     )
+    install_parser.add_argument(
+        '--info', '-i', action="store_true", help="Print game install info instead of downloading" 
+    )
 
     check_for_updates_parser = sub_parsers.add_parser("list-updates")
     check_for_updates_parser.add_argument(

--- a/nile/arguments.py
+++ b/nile/arguments.py
@@ -46,6 +46,9 @@ def get_arguments():
     install_parser.add_argument(
         '--info', '-i', action="store_true", help="Print game install info instead of downloading" 
     )
+    install_parser.add_argument(
+        '--json', '-j', action="store_true", help="Print info in JSON format"
+    )
 
     check_for_updates_parser = sub_parsers.add_parser("list-updates")
     check_for_updates_parser.add_argument(

--- a/nile/cli.py
+++ b/nile/cli.py
@@ -125,12 +125,15 @@ class CLI:
         self.download_manager = manager.DownloadManager(
             self.config, self.library_manager, self.session, matching_game
         )
-        self.download_manager.download(
-            force_verifying=bool(self.arguments.command == "verify"),
-            base_install_path=self.arguments.base_path,
-            install_path=self.arguments.exact_path,
-        )
-        self.logger.info("Download complete")
+        if not self.arguments.info:
+            self.download_manager.download(
+                force_verifying=bool(self.arguments.command == "verify"),
+                base_install_path=self.arguments.base_path,
+                install_path=self.arguments.exact_path,
+            )
+            self.logger.info("Download complete")
+        else:
+            self.download_manager.info()
 
     def list_updates(self):
         installed_array = self.config.get("installed")
@@ -212,8 +215,7 @@ class CLI:
     def handle_uninstall(self):
         uninstaller = Uninstaller(self.config, self.arguments)
         uninstaller.uninstall()
-
-
+    
 def main():
     (arguments, unknown_arguments), parser = get_arguments()
     if arguments.version:

--- a/nile/cli.py
+++ b/nile/cli.py
@@ -153,7 +153,7 @@ class CLI:
             )
             self.logger.info("Download complete")
         else:
-            self.download_manager.info()
+            self.download_manager.info(self.arguments.json)
 
     def list_updates(self):
         installed_array = self.config.get("installed")

--- a/nile/downloading/manager.py
+++ b/nile/downloading/manager.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -145,6 +146,20 @@ class DownloadManager:
 
         if not force_verifying:
             self.finish()
+
+    def info(self):
+        self.manifest = self.get_manifest()
+
+        if not self.manifest:
+            self.logger.error("Unable to load manifest")
+            return
+        self.logger.debug(f"Number of packages: {len(self.manifest.packages)}")
+
+        total_size = sum(f.size for f in self.manifest.packages[0].files)
+        output = {
+            'download_size': total_size
+        }
+        print(json.dumps(output))
 
     def finish(self):
         # Save manifest to the file

--- a/nile/downloading/manager.py
+++ b/nile/downloading/manager.py
@@ -113,10 +113,7 @@ class DownloadManager:
             self.logger.info("Game is up to date")
             return
         total_size = sum(f.download_size for f in patchmanifest.files)
-        readable_size = dl_utils.get_readable_size(total_size)
-        self.logger.info(
-            f"Download size: {round(readable_size[0],2)}{readable_size[1]}"
-        )
+        self.info()
 
         if not dl_utils.check_available_space(total_size, game_location):
             self.logger.error("Not enough space available")
@@ -149,7 +146,7 @@ class DownloadManager:
         if not force_verifying:
             self.finish()
 
-    def info(self):
+    def info(self, json_format=False):
         self.manifest = self.get_manifest()
 
         if not self.manifest:
@@ -158,10 +155,16 @@ class DownloadManager:
         self.logger.debug(f"Number of packages: {len(self.manifest.packages)}")
 
         total_size = sum(f.size for f in self.manifest.packages[0].files)
-        output = {
-            'download_size': total_size
-        }
-        print(json.dumps(output))
+        if json_format:
+            output = {
+                'download_size': total_size
+            }
+            print(json.dumps(output))
+        else:
+            readable_size = dl_utils.get_readable_size(total_size)
+            self.logger.info(
+                f"Download size: {round(readable_size[0],2)}{readable_size[1]}"
+            )
 
     def finish(self):
         # Save manifest to the file


### PR DESCRIPTION
## Why

We currently don't have a way to get some information about a game without also downloading it. Mainly, the download size of the game.

## Changes

- Added --info flag to install action
- Printing JSON output with `download_size`

## Notes

I tried to figure out if there's a `size on disk` in addition to a `download_size`, but anything I tried returned the same size as download.

Not sure if this means that the games pretty much don't need to be unpacked and are downloaded with the final size on disk already or not. If someone can fill me in on that, that'd be great!