### PR TITLE
feat: better support other platforms

### DIFF
--- a/nile/constants.py
+++ b/nile/constants.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from platformdirs import user_config_dir
 
 MARKETPLACEID = "ATVPDKIKX0DER"
 AMAZON_API = "https://api.amazon.com"
@@ -13,7 +14,7 @@ DEFAULT_INSTALL_PATH = os.path.join(
 )
 
 CONFIG_PATH = os.path.join(
-    os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "nile"
+    os.getenv("XDG_CONFIG_HOME", user_config_dir()), "nile"
 )
 if sys.platform == "win32":
     CONFIG_PATH = os.path.join(os.getenv("APPDATA"), "nile")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
   "protobuf",
   "pycryptodome",
   "zstandard",
-  "json5"
+  "json5",
+  "platformdirs"
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ protobuf
 pycryptodome
 zstandard
 json5
+platformdirs


### PR DESCRIPTION
## Why

Currently the config is always stored in `~/.config` by default. This is not the expected path for configuration folders in macOS or Windows.

## Changes

This PR changes the default config folder to be placed where each platform would expect it:

- `~/.config/nile` for Linux
- `~/Library/Application Support/nile` for macOS
- `%USERPROFILE%\AppData\Local\nile` for Windows

I don't think there's a need to have a migration process because as it stands, this project is only advertised as Linux compatible, and that folder will remain the same.