### PR TITLE
fix: Windows path constants

### DIFF
--- a/nile/constants.py
+++ b/nile/constants.py
@@ -14,12 +14,8 @@ DEFAULT_INSTALL_PATH = os.path.join(
 )
 
 CONFIG_PATH = os.path.join(
-    os.getenv("XDG_CONFIG_HOME", user_config_dir()), "nile"
+    os.getenv("XDG_CONFIG_HOME", user_config_dir(roaming=True)), "nile"
 )
-if sys.platform == "win32":
-    CONFIG_PATH = os.path.join(os.getenv("APPDATA"), "nile")
-    DEFAULT_INSTALL_PATH = os.path.join(os.getenv("USERPROFILE"), "nile")
-
 
 ILLEGAL_FNAME_CHARS = ["?", ":", '"', "*", "<", ">", "|"]
 


### PR DESCRIPTION
## Why

We no longer need the `sys.platform` checks for paths since #33. Having the `XDG_CONFIG_HOME` override is also useful for Heroic to be able to keep a separate config for itself.

## Changes

- Removed `sys.platform == "win32"` check
- Using %APPDATA% on Windows as the default config location

EDIT:

I have verified these changes on Windows