### PR TITLE
feat: Import games

### DIFF
--- a/nile/arguments.py
+++ b/nile/arguments.py
@@ -1,3 +1,5 @@
+from os import path
+
 def get_arguments():
     import argparse
 
@@ -78,5 +80,8 @@ def get_arguments():
         "uninstall", help="Uninstall game - deletes game files specified in manifest"
     )
     uninstall_parser.add_argument("id", help="Game id")
+    import_parser = sub_parsers.add_parser("import", help="Import games installed outside nile")
+    import_parser.add_argument("--path", help="Path to the game's installation folder", type=path.abspath)
+    import_parser.add_argument("id", help="The id of the game to import")
 
     return parser.parse_known_args(), parser

--- a/nile/cli.py
+++ b/nile/cli.py
@@ -276,9 +276,9 @@ class CLI:
             self.config, self.library_manager, self.session, matching_game
         )
         importer = Importer(
-            path, self.config, self.library_manager, self.session, self.download_manager
+            game, path, self.config, self.library_manager, self.session, self.download_manager
         )
-        importer.import_game(game)
+        importer.import_game()
  
 def main():
     (arguments, unknown_arguments), parser = get_arguments()

--- a/nile/cli.py
+++ b/nile/cli.py
@@ -9,6 +9,7 @@ from nile.downloading import manager
 from nile.utils.config import Config
 from nile.utils.launch import Launcher
 from nile.utils.uninstall import Uninstaller
+from nile.utils.importer import Importer
 from nile.api import authorization, session, library
 from nile import constants, version, codename
 
@@ -236,6 +237,49 @@ class CLI:
         uninstaller = Uninstaller(self.config, self.arguments)
         uninstaller.uninstall()
     
+    def handle_import(self):
+        id = self.arguments.id
+        if not id:
+            self.logger.error("id is required")
+            return
+
+        path = self.arguments.path
+        if not path:
+            self.logger.error("--path is required")
+            return
+        
+        games = self.config.get("library")
+        matching_game = None
+        self.logger.info(f"Searching for {self.arguments.id}")
+        for game in games:
+            if game["product"]["id"] == self.arguments.id:
+                matching_game = game
+                break
+        if not matching_game:
+            self.logger.error("No game match")
+            return
+        self.logger.debug(f"Found {matching_game['product']['title']}")
+
+        self.logger.debug(
+            f"Checking if game {matching_game['product']['title']} id: {matching_game['id']} is already installed"
+        )
+        installed_games = self.config.get("installed")
+
+        if installed_games:
+            for installed_game in installed_games:
+                if installed_game["id"] == matching_game["product"]["id"]:
+                    self.logger.error(
+                        f"{matching_game['product']['title']} is already installed"
+                    )
+                    return
+        self.download_manager = manager.DownloadManager(
+            self.config, self.library_manager, self.session, matching_game
+        )
+        importer = Importer(
+            path, self.config, self.library_manager, self.session, self.download_manager
+        )
+        importer.import_game(game)
+ 
 def main():
     (arguments, unknown_arguments), parser = get_arguments()
     if arguments.version:
@@ -274,6 +318,8 @@ def main():
         cli.handle_launch()
     elif command == "uninstall":
         cli.handle_uninstall()
+    elif command == "import":
+        cli.handle_import()
     else:
         print(
             "You didn't provide any argument, GUI will be there someday, for now here is help"

--- a/nile/utils/importer.py
+++ b/nile/utils/importer.py
@@ -1,0 +1,66 @@
+import os
+import logging
+from nile.models import manifest
+from nile.downloading.worker import DownloadWorker
+from nile.downloading.progress import ProgressBar
+import nile.utils.download as dl_utils
+
+class Importer:
+    def __init__(self, folder_path, config, library_manager, session_manager, download_manager):
+        self.folder_path = folder_path
+        self.config = config
+        self.library_manager = library_manager
+        self.session_manager = session_manager
+        self.download_manager = download_manager
+        self.logger = logging.getLogger("IMPORT")
+
+    def import_game(self, game):
+        if not os.path.isdir(self.folder_path):
+            self.logger.error(f"{self.folder_path} is not a directory")
+            return
+
+        fuel_path = os.path.join(self.folder_path, "fuel.json")
+        if not os.path.isfile(os.path.join(self.folder_path, "fuel.json")):
+            self.logger.error(f"{fuel_path} is not a file")
+            return
+
+        game_manifest = self.library_manager.get_game_manifest(game['id'])
+
+        download_url = game_manifest["downloadUrls"][0]
+        self.logger.debug("Getting protobuff manifest")
+        response = self.session_manager.session.get(download_url)
+        r_manifest = manifest.Manifest()
+        self.logger.debug("Parsing manifest data")
+        r_manifest.parse(response.content)
+
+        self.download_manager.version = game_manifest["versionId"]
+        comparison = manifest.ManifestComparison.compare(
+            r_manifest
+        )
+        patchmanifest = self.download_manager.get_patchmanifest(comparison)
+
+        fuel_json = None
+        for file in patchmanifest.files:
+            self.logger.debug(f"File: {file.filename}")
+            if file.filename == "fuel.json":
+                fuel_json = file
+                break
+
+        if not fuel_json:
+            self.logger.error("Could not find fuel.json in manifest")
+            return
+
+        readable_size = dl_utils.get_readable_size(fuel_json.download_size)
+        worker = DownloadWorker(
+            fuel_json,
+            fuel_path,
+            self.session_manager,
+            None
+        )
+        if not worker.verify_downloaded_file(fuel_path):
+            self.logger.error(
+                f"{fuel_path} does not match the signature for {game['product']['title']} ({game['product']['id']})"
+            )
+            return
+
+        self.logger.info(f"\tImporting {game['product']['title']} ({game['product']['id']})")

--- a/nile/utils/importer.py
+++ b/nile/utils/importer.py
@@ -2,8 +2,6 @@ import os
 import logging
 from nile.models import manifest
 from nile.downloading.worker import DownloadWorker
-from nile.downloading.progress import ProgressBar
-import nile.utils.download as dl_utils
 
 class Importer:
     def __init__(self, folder_path, config, library_manager, session_manager, download_manager):
@@ -50,7 +48,6 @@ class Importer:
             self.logger.error("Could not find fuel.json in manifest")
             return
 
-        readable_size = dl_utils.get_readable_size(fuel_json.download_size)
         worker = DownloadWorker(
             fuel_json,
             fuel_path,


### PR DESCRIPTION
## Why

We currently don't have a way to import already downloaded games

## Changes

- Added cli action to import an already downloaded game
- Checking local files' integrity before importing

## Notes

We verify the checksum of every file against the latest manifest.

The reason for this is simple: updates. When importing, we don't have access to the originally downloaded manifest, so we can't handle updates for the game properly.

To avoid issues, I think it's better for the user to re-download the game if they have an older version.