### PR TITLE
fix: output valid JSON if no games installed

### DIFF
--- a/nile/cli.py
+++ b/nile/cli.py
@@ -165,6 +165,10 @@ class CLI:
         games = self.config.get("library")
 
         if not installed_array:
+            if self.arguments.json:
+                # An empty string is not valid JSON, so create an empty but
+                # valid JSON string instead.
+                print(json.dumps(list()))
             self.logger.error("No games installed")
             return
 


### PR DESCRIPTION
Unfortunately, an empty string is not valid JSON, so if JSON mode has been requested, make sure to output an empty JSON string if there are no games installed while checking for updates.