### PR TITLE
Fix uninstall paths on windows

### DIFF
--- a/nile/utils/uninstall.py
+++ b/nile/utils/uninstall.py
@@ -32,6 +32,17 @@ class Uninstaller:
             # Manifest can contain both kind of slash as a separator on the same entry
             os.remove(os.path.join(installed_info["path"], f.path.replace("\\", os.sep).replace("/", os.sep)))
 
+        # Remove empty directories under the installation directory
+        for dirpath, dirnames, filenames in os.walk(installed_info["path"], topdown=False):
+            for dirname in dirnames:
+                full_path = os.path.join(dirpath, dirname)
+                if not os.listdir(full_path):
+                    os.rmdir(full_path)
+
+        # Remove installation directory if it's empty
+        if not os.listdir(installed_info["path"]):
+            os.rmdir(installed_info["path"])
+
         self.config.write("installed", installed_games)
         self.config.remove(f"manifests/{game_id}", cfg_type=ConfigType.RAW)
         self.logger.info("Game removed successfully")

--- a/nile/utils/uninstall.py
+++ b/nile/utils/uninstall.py
@@ -29,7 +29,8 @@ class Uninstaller:
 
         files = self.manifest.packages[0].files
         for f in files:
-            os.remove(os.path.join(installed_info["path"], f.path.replace("\\", "/")))
+            # Manifest can contain both kind of slash as a separator on the same entry
+            os.remove(os.path.join(installed_info["path"], f.path.replace("\\", os.sep).replace("/", os.sep)))
 
         self.config.write("installed", installed_games)
         self.config.remove(f"manifests/{game_id}", cfg_type=ConfigType.RAW)


### PR DESCRIPTION
This PR contains two modifications.

First one should fix uninstallation problems on windows. Some of the manifest files contains mixed slashes in the same path so we should make double replacement scans.

Second one handles empty directories which remains after uninstallation.

Both changes had been tested on Ubuntu 22.04 (running under WSL2) and on Windows 11 (running PyInstaller binary from within PowerShell)