### PR TITLE
fix: Do not break uninstall when file is missing

### DIFF
--- a/nile/utils/uninstall.py
+++ b/nile/utils/uninstall.py
@@ -27,10 +27,13 @@ class Uninstaller:
         # Load manifest
         self.manifest = self.load_installed_manifest(game_id)
 
-        files = self.manifest.packages[0].files
-        for f in files:
+        for f in self.manifest.packages[0].files:
             # Manifest can contain both kind of slash as a separator on the same entry
-            os.remove(os.path.join(installed_info["path"], f.path.replace("\\", os.sep).replace("/", os.sep)))
+            filepath = os.path.join(installed_info["path"], f.path.replace("\\", os.sep).replace("/", os.sep))
+            try:
+                os.remove(filepath)
+            except FileNotFoundError:
+                self.logger.warning(f'Missing file "{filepath}" - skipping')
 
         # Remove empty directories under the installation directory
         for dirpath, dirnames, filenames in os.walk(installed_info["path"], topdown=False):


### PR DESCRIPTION
Currently, when file is missing from disk, uninstall operation breaks with unhandled exception and does not update the `installed_games` store. 

Such situation can happen when we try to remove the game while it's still running (`PermissionError` exception). Because some of the files were already removed, user can no longer uninstall game unless he verifies it (and downloads missing files) first.

With current proposal, we gracefully handle `FileNotFoundError` so user can safely uninstall game in case of missing files, or any other unhandled exceptions from previous attempts.