### PR TITLE
Add possibility to provide user data as argument or environment variable

### DIFF
--- a/nile/api/authorization.py
+++ b/nile/api/authorization.py
@@ -9,6 +9,7 @@ import secrets
 import base64
 import uuid
 import json
+from nile.arguments import get_arguments
 
 
 class AuthenticationManager:
@@ -117,6 +118,10 @@ class AuthenticationManager:
         self.logger.info("Written data to the config")
 
     def refresh_token(self):
+        (arguments, unknown_arguments), parser = get_arguments()
+        if arguments.secret_user_data:
+            self.logger.error("Token expired, you need to refresh it manually.")
+            return None
         url = f"{constants.AMAZON_API}/auth/token"
         self.logger.info("Refreshing token")
         user_conf_content = self.config.get("user")

--- a/nile/arguments.py
+++ b/nile/arguments.py
@@ -1,3 +1,4 @@
+from os import environ
 from os import path
 
 def get_arguments():
@@ -10,6 +11,7 @@ def get_arguments():
         action="store_true",
         help="Display nile version",
     )
+    parser.add_argument("--secret-user-data", dest="secret_user_data", help="Provide userdata in base64 encoded json format", type=str, default=environ.get("NILE_SECRET_USER_DATA"))
     sub_parsers = parser.add_subparsers(dest="command")
 
     auth_parser = sub_parsers.add_parser("auth", help="Authorization related things")


### PR DESCRIPTION
I don't like storing it in plain text, so added a way to provide user data in environment variable (`NILE_SECRET_USER_DATA`) or as argument (`--secret-user-data`). That way could be encrypted by other app and reused by nile.

I used base64 encoded format, cuz easier with parsing :smile:.