### PR TITLE
fix(build): configure setuptools package discovery to exclude assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,10 @@ nile = "nile.cli:main"
 [project.urls]
 Issues = "https://github.com/imLinguin/nile/issues"
 
+[tool.setuptools.packages.find]
+exclude = ["assets*"]
+
 [tool.setuptools.dynamic]
 version = {attr = "nile.version"}
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ nile = "nile.cli:main"
 Issues = "https://github.com/imLinguin/nile/issues"
 
 [tool.setuptools.packages.find]
-exclude = ["assets*"]
+exclude = ["assets", "assets.*"]
+
 
 [tool.setuptools.dynamic]
 version = {attr = "nile.version"}


### PR DESCRIPTION
### Description
My version of `setuptools` raises a `PackageDiscoveryError` (multiple top-level packages discovered in flat-layout) because of the `assets/` folder. 

This change configures `setuptools` to explicitly exclude the `assets` folder from package discovery, allowing the project to build and install cleanly.

### Steps to reproduce the error (prior to fix):
```bash
python -m build
# setuptools.errors.PackageDiscoveryError: Multiple top-level packages discovered in a flat-layout: ['nile', 'assets'].